### PR TITLE
Add support for nested partials

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
     "prepare": "@php vendor/bin/testbench package:discover --ansi",
     "pint": "@php vendor/bin/pint",
     "test": "@php vendor/bin/phpunit",
-    "facade": "@php vendor/bin/facade.php -- Elide\\\\Htmx"
+    "facade": "@php vendor/bin/facade.php -- Elide\\\\Htmx",
+    "clear": "@php vendor/bin/testbench view:clear"
   }
 }

--- a/src/Http/HtmxResponse.php
+++ b/src/Http/HtmxResponse.php
@@ -146,17 +146,15 @@ class HtmxResponse implements Responsable
             );
         }
 
-        $props = ['partials' => $partials->toArray()];
-
         if ($this->title) {
-            $props['title'] = $this->title;
+            $sharedProps['title'] = $this->title;
         }
 
-        IlluminateView::share($props);
+        IlluminateView::share($sharedProps);
 
         return Response::view(
             $this->rootView,
-            $props,
+            $sharedProps,
             status: $this->status,
             headers: $this->headers->all(),
         );

--- a/src/Services/Htmx.php
+++ b/src/Services/Htmx.php
@@ -60,7 +60,7 @@ class Htmx
     /**
      * Specify a new callable which, when invoked, will return an array of Partials/Views/Components.
      *
-     * @param  array<callable():(array<int, Partial|View|Component|string>)  $callable
+     * @param  callable():(array<int, Partial|View|Component|string>)  $callable
      * @return $this
      */
     public function usingPartials(callable $callable, RequestKind $for = RequestKind::BOTH): static

--- a/workbench/app/View/Components/PartialNesting/ChildComponentComponent.php
+++ b/workbench/app/View/Components/PartialNesting/ChildComponentComponent.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\View\Components\PartialNesting;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class ChildComponentComponent extends Component
+{
+    public function render(): View
+    {
+        return view('test::partial-nesting.child-component');
+    }
+}

--- a/workbench/app/View/Components/PartialNesting/ParentComponentComponent.php
+++ b/workbench/app/View/Components/PartialNesting/ParentComponentComponent.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\View\Components\PartialNesting;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class ParentComponentComponent extends Component
+{
+    public function render(): View
+    {
+        return view('test::partial-nesting.parent-component');
+    }
+}

--- a/workbench/resources/views/partial-nesting/child-component.blade.php
+++ b/workbench/resources/views/partial-nesting/child-component.blade.php
@@ -1,0 +1,3 @@
+<div id="#child-component">
+    [the child component]
+</div>

--- a/workbench/resources/views/partial-nesting/parent-component.blade.php
+++ b/workbench/resources/views/partial-nesting/parent-component.blade.php
@@ -1,0 +1,6 @@
+<div id="#parent-component">
+    [the parent component]
+
+    @htmxPartial('child-component-component')
+
+</div>


### PR DESCRIPTION
Progressively merges the stack of rendered partials into shared view for reference.

NB: For a nested partial to be available for other partials/components, it must be rendered before the component/partial which wants to use it. That is, it should be declared earlier in the full list of partials