### PR TITLE
Provides the "current" `Partial`'s ID with HTMX requests

### DIFF
--- a/docs/digging-deeper/htmx-render.md
+++ b/docs/digging-deeper/htmx-render.md
@@ -95,3 +95,10 @@ if (cartWasUpdated()) {
   
 Htmx::render(ProductDetails::class, props: ['product' => $product]);
 ```
+
+## Scoping the response to specific partials
+
+Elide can automatically detect which partial an HTMX AJAX request came from, and optionally scope down to return just that partial.
+
+See [`Htmx::Response` - Scoping the response to specific partials](htmx-response.md#Scoping%20the%20response%20to%20specific%20partials)
+

--- a/docs/digging-deeper/htmx-request.md
+++ b/docs/digging-deeper/htmx-request.md
@@ -99,9 +99,22 @@ use Elide\Http\HtmxRequest;
 $trigger = app(HtmxRequest::class)->trigger();
 ```
 
-### `inspect()`
+## Available Elide inspections
 
-Returns an array of all the HTMX related values.
+### `partialId()`
+
+Check which frontend `Partial` triggered the request.
+
+```php
+use Elide\Http\HtmxRequest;
+
+$partialId = app(HtmxRequest::class)->partialId();
+```
+
+
+## Debugging the request with `inspect()`
+
+The `inspect()` method returns an array of all the HTMX related values.
 
 ```php
 use Elide\Http\HtmxRequest;

--- a/docs/digging-deeper/htmx-response.md
+++ b/docs/digging-deeper/htmx-response.md
@@ -134,3 +134,66 @@ return (new \Elide\Http\HtmxResponse)->reselect($event);
 ```
 
 See https://htmx.org/headers/hx-trigger/
+
+## Scoping the response to specific partials
+
+You can instruct Elide to return _only_ a specific partial, if an HTMX AJAX request has come from that partial, with the `scopeToRequestingPartial()` method.
+
+```php
+Htmx::render(...)->scopeToRequestingPartial();
+```
+
+You may enable scoping by calling the method, optionally passing `true` as the argument.
+
+```php
+Htmx::render(...)->scopeToRequestingPartial();
+// or
+Htmx::render(...)->scopeToRequestingPartial(shouldScope: true);
+```
+
+> [!TIP]
+> If the requested partial is not available in the partials provided for the response, the response will include all provided partials as per default behaviour.
+
+You may allow scoping for specific partials by providing an array of IDs:
+
+```php
+Htmx::render(...)->scopeToRequestingPartial(['user-profile-widget']]);
+```
+
+> [!TIP]
+> If the requested partial is not included in the list of partials to scope to, the response will include all provided partials as per default behaviour.
+
+You may disable scoping by passing `false`, or calling `doNotScopeToRequestingPartial()`.
+
+```php
+Htmx::render(...)->scopeToRequestingPartial(shouldScope: false);
+// or
+Htmx::render(...)->doNotScopeToRequestingPartial();
+```
+
+### An example
+
+For example, we have a route which returns a transactions page for a bank account, and in this page is a transactions table (amongst other things):
+
+```php
+use App\View\Components\Page\BankAccountTransactionsPage;
+use App\View\Components\Shared\MainNavigation;
+use App\View\Components\Shared\UserProfileWidget;
+use App\View\Components\Tables\AccountTransactionsTable;
+use Elide\Htmx;
+
+Route::get('transactions', function (BankAccount $bankAccount) {
+    return Htmx::render(BankAccountTransactionsPage::class)
+        ->usingPartials(fn() => [
+            MainNavigation::class,
+            UserProfileWidget::class,
+            new AccountTransactionsTable($bankAccount),
+        ]);
+});
+```
+
+The transaction table is paginated, and has <kbd>Previous</kbd> and <kbd>Next</kbd> links which will fire an HTMX AJAX request.
+
+Currently, any HTMX AJAX request made to this route will include all specified partials.
+
+Adding `scopeToRequestingPartial()` to the route's response will instruct the route to only return the `AccountTransactionsTable` for the <kbd>Previous</kbd> and <kbd>Next</kbd> links.

--- a/src/Enums/Headers.php
+++ b/src/Enums/Headers.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace Elide\Enums;
+
+enum Headers: string
+{
+    case ELIDE_PARTIAL_ID = 'X-Elide-Partial-Id';
+}

--- a/src/Enums/Headers.php
+++ b/src/Enums/Headers.php
@@ -2,10 +2,18 @@
 
 declare(strict_types=1);
 
-
 namespace Elide\Enums;
 
 enum Headers: string
 {
     case ELIDE_PARTIAL_ID = 'X-Elide-Partial-Id';
+
+    case HTMX_BOOSTED = 'HX-Boosted';
+    case HTMX_CURRENT_URL = 'HX-Current-Url';
+    case HTMX_HISTORY_RESTORE_REQUEST = 'HX-History-Restore-Request';
+    case HTMX_PROMPT = 'HX-Prompt';
+    case HTMX_REQUEST = 'HX-Request';
+    case HTMX_TARGET = 'HX-Target';
+    case HTMX_TRIGGER_NAME = 'HX-Trigger-Name';
+    case HTMX_TRIGGER = 'HX-Trigger';
 }

--- a/src/Http/HtmxRequest.php
+++ b/src/Http/HtmxRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Elide\Http;
 
+use Elide\Enums\Headers;
 use Illuminate\Http\Request;
 
 class HtmxRequest extends Request
@@ -72,6 +73,10 @@ class HtmxRequest extends Request
         return $this->header('HX-Trigger');
     }
 
+    public function partialId(): ?string {
+        return $this->header(Headers::ELIDE_PARTIAL_ID->value);
+    }
+
     /**
      * The HTMX properties of the request.
      */
@@ -86,6 +91,7 @@ class HtmxRequest extends Request
             'target' => $this->target(),
             'triggerName' => $this->triggerName(),
             'trigger' => $this->trigger(),
+            'elidePartialId' => $this->partialId(),
         ];
     }
 }

--- a/src/Http/HtmxRequest.php
+++ b/src/Http/HtmxRequest.php
@@ -14,7 +14,7 @@ class HtmxRequest extends Request
      */
     public function isBoosted(): bool
     {
-        return $this->hasHeader('HX-Boosted');
+        return $this->hasHeader(Headers::HTMX_BOOSTED->value);
     }
 
     /**
@@ -22,7 +22,7 @@ class HtmxRequest extends Request
      */
     public function currentUrl(): ?string
     {
-        return $this->header('HX-Current-Url');
+        return $this->header(Headers::HTMX_CURRENT_URL->value);
     }
 
     /**
@@ -30,7 +30,7 @@ class HtmxRequest extends Request
      */
     public function isHistoryRestoreRequest(): bool
     {
-        return $this->header('HX-History-Restore-Request') === 'true';
+        return $this->header(Headers::HTMX_HISTORY_RESTORE_REQUEST->value) === 'true';
     }
 
     /**
@@ -38,7 +38,7 @@ class HtmxRequest extends Request
      */
     public function isPrompt(): bool
     {
-        return $this->header('HX-Prompt') === 'true';
+        return $this->header(Headers::HTMX_PROMPT->value) === 'true';
     }
 
     /**
@@ -46,7 +46,7 @@ class HtmxRequest extends Request
      */
     public function isHtmxRequest(): bool
     {
-        return $this->header('HX-Request') === 'true';
+        return $this->header(Headers::HTMX_REQUEST->value) === 'true';
     }
 
     /**
@@ -54,7 +54,7 @@ class HtmxRequest extends Request
      */
     public function target(): ?string
     {
-        return $this->header('HX-Target');
+        return $this->header(Headers::HTMX_TARGET->value);
     }
 
     /**
@@ -62,7 +62,7 @@ class HtmxRequest extends Request
      */
     public function triggerName(): ?string
     {
-        return $this->header('HX-Trigger-Name');
+        return $this->header(Headers::HTMX_TRIGGER_NAME->value);
     }
 
     /**
@@ -70,10 +70,11 @@ class HtmxRequest extends Request
      */
     public function trigger(): ?string
     {
-        return $this->header('HX-Trigger');
+        return $this->header(Headers::HTMX_TRIGGER->value);
     }
 
-    public function partialId(): ?string {
+    public function partialId(): ?string
+    {
         return $this->header(Headers::ELIDE_PARTIAL_ID->value);
     }
 

--- a/src/Http/HtmxResponse.php
+++ b/src/Http/HtmxResponse.php
@@ -86,7 +86,7 @@ class HtmxResponse implements Responsable
      */
     public function status(int $code): static
     {
-        if (!array_key_exists($code, SymfonyResponse::$statusTexts)) {
+        if (! array_key_exists($code, SymfonyResponse::$statusTexts)) {
             throw new \InvalidArgumentException(sprintf(
                 'Provided code "%s" is not a valid HTTP status code.',
                 $code,
@@ -110,13 +110,13 @@ class HtmxResponse implements Responsable
         /** @var Collection $partials */
         $partials =
             collect($this->usingPartials)
-                ->map(fn(callable $partial) => $partial())
+                ->map(fn (callable $partial) => $partial())
                 ->flatten(1)
-                ->map(fn(Partial|View|Component|string $partial) => Partial::resolveFrom($partial))
+                ->map(fn (Partial|View|Component|string $partial) => Partial::resolveFrom($partial))
                 ->when($this->component, function (Collection $collection) {
                     $collection->push($this->partial);
                 })
-                ->groupBy(fn(Partial $partial) => $partial->name)
+                ->groupBy(fn (Partial $partial) => $partial->name)
                 ->map(function (Collection $group, string $key) use (&$sharedProps) {
                     $renderedGroup = $group->map->render()->join("\n");
                     $sharedProps['partials'][$key] = $renderedGroup;
@@ -150,7 +150,7 @@ class HtmxResponse implements Responsable
             );
         }
 
-        if (!$this->component) {
+        if (! $this->component) {
             return response(
                 content: null,
                 status: $this->status,

--- a/src/Http/HtmxResponse.php
+++ b/src/Http/HtmxResponse.php
@@ -340,4 +340,14 @@ class HtmxResponse implements Responsable
 
         return $this;
     }
+
+    /**
+     * Disable scoping to the requested partial.
+     */
+    public function doNotScopeToRequestingPartial(): static
+    {
+        $this->scopeToRequestingPartial(false);
+
+        return $this;
+    }
 }

--- a/src/View/Partial.php
+++ b/src/View/Partial.php
@@ -6,6 +6,7 @@ namespace Elide\View;
 
 use Elide\Contracts\ComponentSpecifiesSwapStrategy;
 use Elide\Contracts\ProvidesPartialName;
+use Elide\Enums\Headers;
 use Elide\Http\HtmxRequest;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
@@ -100,11 +101,12 @@ class Partial
         );
 
         return sprintf(
-            '<%1$s id="partial:%2$s" style="display: contents;"%4$s>%3$s</%1$s>',
+            '<%1$s id="partial:%2$s" hx-headers="%5$s" style="display: contents;"%4$s>%3$s</%1$s>',
             e($this->enclosingTagName),
             e($this->name),
             $content,
             $isHtmxRequest ? sprintf(' hx-swap-oob="%s"', e($swapTarget)) : '',
+            e(json_encode([Headers::ELIDE_PARTIAL_ID->value => $this->name])),
         );
     }
 }

--- a/tests/Feature/PartialTest.php
+++ b/tests/Feature/PartialTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Feature;
 
+use Elide\Enums\Headers;
 use Elide\Htmx;
 use Tests\TestCase;
 use Workbench\App\View\Components\TestComponent;
@@ -100,5 +101,37 @@ class PartialTest extends TestCase
         $expected = sprintf('hx-swap-oob="%s"', $strategy);
 
         $this->assertStringContainsString($expected, $content);
+    }
+
+    public function test_it_includes_partial_id_header(): void
+    {
+        $request = app('request');
+        $request->headers->set('HX-Request', 'true');
+        app()->instance('request', $request);
+
+        $partial = Htmx::partial('test::test-component');
+
+        $attributeValue = e(json_encode([Headers::ELIDE_PARTIAL_ID->value => $partial->name]));
+        $attribute = sprintf('hx-headers="%s"', $attributeValue);
+        $content = $partial->render();
+
+        $this->assertStringContainsString($attribute, $content);
+    }
+
+    public function test_it_includes_partial_id_header_when_partial_name_is_custom(): void
+    {
+        $request = app('request');
+        $request->headers->set('HX-Request', 'true');
+        app()->instance('request', $request);
+
+        $customName = 'custom-partial-name';
+        $partial = Htmx::partial('test::test-component', name: $customName);
+
+        $attributeValue = e(json_encode([Headers::ELIDE_PARTIAL_ID->value => $partial->name]));
+        $attribute = sprintf('hx-headers="%s"', $attributeValue);
+        $content = $partial->render();
+
+        $this->assertStringContainsString($customName, $attribute);
+        $this->assertStringContainsString($attribute, $content);
     }
 }


### PR DESCRIPTION
Original intent was to include the stack/chain of `Partial`s in a header, however that's more involved. TBD in the future.

This feature updates rendered `Partial`s to provide an `X-Elide-Partial-Id` header for HTMX when generating AJAX responses.

There's also a new `->scopeToRequestingPartial()` method for easy application of "only return the requesting partial" if/when it's provided for AJAX requests.

An example: a partial displays a table of transaction records as part of a full "bank account transactions page".

```php
use App\View\Components\Page\BankAccountTransactionsPage;
use App\View\Components\Shared\MainNavigation;
use App\View\Components\Shared\UserProfileWidget;
use App\View\Components\Tables\AccountTransactionsTable;
use Elide\Htmx;

Route::get('transactions', function (BankAccount $bankAccount) {
    return Htmx::render(BankAccountTransactionsPage::class)
        ->usingPartials(fn() => [
            MainNavigation::class,
            UserProfileWidget::class,
            new AccountTransactionsTable($bankAccount),
        ])
        ->scopeToRequestingPartial();
});
```

In this scenario, if someone clicks a "next page" from within the rendered `AccountTransactionsTable`, _only_ that partial will be returned.